### PR TITLE
Add Bioindex Server Request Logging

### DIFF
--- a/bioindex/main.py
+++ b/bioindex/main.py
@@ -31,6 +31,34 @@ def cli(ctx, env_file):
     ctx.obj = config.Config()
 
 
+SERVER_LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": "access.log",
+            "maxBytes": 1024 * 1024 * 100,  # 100 MB
+            "backupCount": 3,  # keep 3 backup files
+        }
+    },
+    "root": {"level": "INFO", "handlers": ["file"]},
+    "loggers": {
+        "uvicorn.access": {
+            "level": "INFO",
+            "handlers": ["file"],
+            "propagate": True,
+            "formatter": "apache",
+        },
+    },
+    "formatters": {
+        "apache": {
+            "format": '%(message)s "%(status)d" %(bytes)d',
+        },
+    },
+}
+
+
 @click.command(name='serve')
 @click.option('--port', '-p', type=int, default=5000)
 def cli_serve(port):
@@ -39,6 +67,7 @@ def cli_serve(port):
         host='0.0.0.0',
         port=port,
         log_level='info',
+        log_config=SERVER_LOGGING_CONFIG
     )
 
 


### PR DESCRIPTION
This change will create a file called access.log in the root directory for the project and it will contain request info e.g. `127.0.0.1:40554 - "GET /api/bio/query/dataset-associations?q=ExChip_AFGen,AF HTTP/1.1" 500` the main thing I'm interested in capturing are the query api calls.  Those calls are potentially useful in making sure reading from bgzip files doesn't do unexpected things.  This config will store up to 400mb (or maybe it's 300mb I'm not sure) and then roll over so there's not a ticking bomb risk of filling up the disk space.