### PR TITLE
make indexer work against both gz and json files

### DIFF
--- a/bioindex/lib/index.py
+++ b/bioindex/lib/index.py
@@ -147,6 +147,9 @@ class Index:
         logging.info('Finding keys in %s...', self.s3_prefix)
         json_objects = list(list_objects(config.s3_bucket, self.s3_prefix, only='*.json'))
         gz_objects = list(list_objects(config.s3_bucket, self.s3_prefix, only='*.gz'))
+        if len(json_objects) > 0 and len(gz_objects) > 0:
+            raise ValueError(f'There are both compressed and uncompressed files in {self.s3_prefix}. '
+                             f'An index needs to be all one or the other.')
         s3_objects = json_objects + gz_objects
 
         # delete all stale keys; get the list of objects left to index

--- a/bioindex/lib/index.py
+++ b/bioindex/lib/index.py
@@ -146,7 +146,7 @@ class Index:
         """
         logging.info('Finding keys in %s...', self.s3_prefix)
         json_objects = list(list_objects(config.s3_bucket, self.s3_prefix, only='*.json'))
-        gz_objects = list(list_objects(config.s3_bucket, self.s3_prefix, only='*.gz'))
+        gz_objects = list(list_objects(config.s3_bucket, self.s3_prefix, only='*.json.gz'))
         if len(json_objects) > 0 and len(gz_objects) > 0:
             raise ValueError(f'There are both compressed and uncompressed files in {self.s3_prefix}. '
                              f'An index needs to be all one or the other.')

--- a/bioindex/lib/s3.py
+++ b/bioindex/lib/s3.py
@@ -146,7 +146,6 @@ def read_object(bucket, path, offset=None, length=None):
 
     raw = s3_client.get_object(**kwargs).get('Body')
 
-
     if path.endswith('.gz'):
         bytestream = BytesIO(raw.read())
         return gzip.open(bytestream, 'rt')


### PR DESCRIPTION
I tested this with a single file bioindex in compressed and uncompressed forms and verified that the total number of rows in the generated table were the same.  I have not tested this against a real index or when invoked from a lambda.  I admittedly don't understand exactly what is happening in terms of memory usage and I/O to s3.