### PR TITLE
[Bioindex] Need to be able to read straight raw and lined files

### DIFF
--- a/bioindex/lib/index.py
+++ b/bioindex/lib/index.py
@@ -14,7 +14,7 @@ import time
 from sqlalchemy import text
 
 from .aws import invoke_lambda, start_and_wait_for_indexer_job
-from .s3 import list_objects, read_object, relative_key
+from .s3 import list_objects, read_lined_object, relative_key
 from .schema import Schema
 from .utils import cap_case_str
 
@@ -346,7 +346,7 @@ class Index:
         key_id = self.insert_key(engine, key, version)
 
         # read the file from s3
-        content = read_object(bucket, key)
+        content = read_lined_object(bucket, key)
         start_offset = 0
         records = {}
 

--- a/bioindex/lib/reader.py
+++ b/bioindex/lib/reader.py
@@ -7,7 +7,7 @@ import logging
 import orjson
 
 from .auth import verify_record
-from .s3 import read_object
+from .s3 import read_lined_object
 # from . import config
 
 # CONFIG = config.Config()
@@ -116,7 +116,7 @@ class RecordReader:
                             raise subprocess.CalledProcessError(proc.returncode, command, output=stderr)
 
                 else:
-                    content = read_object(self.config.s3_bucket, source.key, offset=source.start,
+                    content = read_lined_object(self.config.s3_bucket, source.key, offset=source.start,
                                           length=source.end - source.start)
 
                     # handle a bad case where the content failed to be read

--- a/bioindex/lib/s3.py
+++ b/bioindex/lib/s3.py
@@ -144,8 +144,11 @@ def read_object(bucket, path, offset=None, length=None):
     elif length is not None:
         kwargs['Range'] = f'bytes=-{length}'
 
-    raw = s3_client.get_object(**kwargs).get('Body')
+    return s3_client.get_object(**kwargs).get('Body')
 
+
+def read_lined_object(bucket, path, offset=None, length=None):
+    raw = read_object(bucket, path, offset, length)
     if path.endswith('.gz'):
         bytestream = BytesIO(raw.read())
         return gzip.open(bytestream, 'rt')


### PR DESCRIPTION
Pulled the gz/iter_lines bit into a new method which reads out of the old method (which returned raw previously). When fetching an image it uses raw, but otherwise I think using the new lined method should work.