### PR TITLE
[Bioindex] Dockerfile update + avoid index error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM --platform=linux/amd64 python:3.8-slim as build
 
 RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev pkg-config build-essential

--- a/bioindex/lib/schema.py
+++ b/bioindex/lib/schema.py
@@ -73,6 +73,8 @@ class Schema:
         self.locus_columns = None
 
         # add table columns that will be indexed
+        max_length = 3048  # bytes, mysql constraint
+        column_size = min(200, max_length // 4 // len(self.schema_columns))
         for column in self.schema_columns:
             if self.locus_class is not None:
                 raise ValueError(f'Invalid schema (locus must be last): {self.schema_str}')
@@ -87,7 +89,7 @@ class Schema:
                     Column('position', Integer),
                 ]
             else:
-                self.index_columns.append(Column(column, String(200)))
+                self.index_columns.append(Column(column, String(column_size)))
                 self.key_columns.append(column)
 
         # ensure a valid schema exists


### PR DESCRIPTION
Small Dockerfile update which should allow for building on different architectures.

Then a small change to indexing where when building a new index it now has a dynamic text range to avoid issues with exceeding the built in 3072 byte maximum for an index.

E.g. in the partitioned-heritability-tissue endpoint the index is on phenotype, ancestry, annotation, tissue, but 200 * 4 * 4 bytes is just over the 3072 byte maximum (3200). So this new method will create the table with VARCHAR(190) instead to get just under 3048 bytes (3072 - 24 maximum bytes on a locus index).