### PR TITLE
Add compression to fastapi server

### DIFF
--- a/bioindex/server.py
+++ b/bioindex/server.py
@@ -6,6 +6,7 @@ from .api import portal
 from .api import raw
 
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -26,6 +27,10 @@ app.add_middleware(
     allow_methods=['*'],
     allow_headers=['*'],
 )
+
+# enable compression of large response bodies
+app.add_middlware(GZipMiddleware)
+
 # serve static content
 app.mount('/static', StaticFiles(directory="web/static"), name="static")
 

--- a/bioindex/server.py
+++ b/bioindex/server.py
@@ -1,3 +1,10 @@
+import dotenv
+import os
+import pathlib
+
+env_loc = os.path.join(pathlib.Path(__file__).parent.parent, '.bioindex')
+dotenv.load_dotenv(env_loc)
+
 import fastapi
 import pymysql
 
@@ -29,7 +36,7 @@ app.add_middleware(
 )
 
 # enable compression of large response bodies
-app.add_middlware(GZipMiddleware)
+app.add_middleware(GZipMiddleware)
 
 # serve static content
 app.mount('/static', StaticFiles(directory="web/static"), name="static")


### PR DESCRIPTION
Currently, the fastapi server does not support compressing large response bodies. This PR adds the built in fastapi gzip middleware to the server to allow for gzip compression of large responses.